### PR TITLE
Use setProperty instead of put

### DIFF
--- a/AvroConsumerExample/src/main/java/com/shapira/examples/consumer/avroclicks/AvroClicksSessionizer.java
+++ b/AvroConsumerExample/src/main/java/com/shapira/examples/consumer/avroclicks/AvroClicksSessionizer.java
@@ -47,14 +47,14 @@ public class AvroClicksSessionizer {
 
     private Properties createConsumerConfig(String brokers, String groupId, String url) {
         Properties props = new Properties();
-        props.put("bootstrap.servers", brokers);
-        props.put("group.id", groupId);
-        props.put("auto.commit.enable", "false");
-        props.put("auto.offset.reset", "earliest");
-        props.put("schema.registry.url", url);
-        props.put("specific.avro.reader", true);
-        props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
-        props.put("value.deserializer", "io.confluent.kafka.serializers.KafkaAvroDeserializer");
+        props.setProperty("bootstrap.servers", brokers);
+        props.setProperty("group.id", groupId);
+        props.setProperty("auto.commit.enable", "false");
+        props.setProperty("auto.offset.reset", "earliest");
+        props.setProperty("schema.registry.url", url);
+        props.setProperty("specific.avro.reader", true);
+        props.setProperty("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.setProperty("value.deserializer", "io.confluent.kafka.serializers.KafkaAvroDeserializer");
 
         return props;
     }
@@ -98,12 +98,12 @@ public class AvroClicksSessionizer {
     private KafkaProducer<String, LogLine> getProducer(String topic, String url) {
         Properties props = new Properties();
         // hardcoding the Kafka server URI for this example
-        props.put("bootstrap.servers", "localhost:9092");
-        props.put("acks", "all");
-        props.put("retries", 0);
-        props.put("key.serializer", "io.confluent.kafka.serializers.KafkaAvroSerializer");
-        props.put("value.serializer", "io.confluent.kafka.serializers.KafkaAvroSerializer");
-        props.put("schema.registry.url", url);
+        props.setProperty("bootstrap.servers", "localhost:9092");
+        props.setProperty("acks", "all");
+        props.setProperty("retries", 0);
+        props.setProperty("key.serializer", "io.confluent.kafka.serializers.KafkaAvroSerializer");
+        props.setProperty("value.serializer", "io.confluent.kafka.serializers.KafkaAvroSerializer");
+        props.setProperty("schema.registry.url", url);
 
         KafkaProducer<String, LogLine> producer = new KafkaProducer<String, LogLine>(props);
         return producer;

--- a/AvroProducerExample/src/main/java/com/shapira/examples/producer/avroclicks/AvroClicksProducer.java
+++ b/AvroProducerExample/src/main/java/com/shapira/examples/producer/avroclicks/AvroClicksProducer.java
@@ -20,12 +20,12 @@ public class AvroClicksProducer {
 
         Properties props = new Properties();
         // hardcoding the Kafka server URI for this example
-        props.put("bootstrap.servers", "localhost:9092");
-        props.put("acks", "all");
-        props.put("retries", 0);
-        props.put("key.serializer", "io.confluent.kafka.serializers.KafkaAvroSerializer");
-        props.put("value.serializer", "io.confluent.kafka.serializers.KafkaAvroSerializer");
-        props.put("schema.registry.url", schemaUrl);
+        props.setProperty("bootstrap.servers", "localhost:9092");
+        props.setProperty("acks", "all");
+        props.setProperty("retries", 0);
+        props.setProperty("key.serializer", "io.confluent.kafka.serializers.KafkaAvroSerializer");
+        props.setProperty("value.serializer", "io.confluent.kafka.serializers.KafkaAvroSerializer");
+        props.setProperty("schema.registry.url", schemaUrl);
         // Hard coding topic too.
         String topic = "clicks";
 

--- a/KafkaStreamsAvg/src/main/java/com/shapira/examples/kstreamavg/StreamingAvg.java
+++ b/KafkaStreamsAvg/src/main/java/com/shapira/examples/kstreamavg/StreamingAvg.java
@@ -43,13 +43,13 @@ public class StreamingAvg {
     public static void main(String[] args) throws Exception {
         Properties props = new Properties();
 
-        props.put(StreamingConfig.JOB_ID_CONFIG, "moving-avg-example");
-        props.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        props.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
-        props.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        props.put(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
-        props.put(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
+        props.setProperty(StreamingConfig.JOB_ID_CONFIG, "moving-avg-example");
+        props.setProperty(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.setProperty(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        props.setProperty(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.setProperty(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        props.setProperty(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.setProperty(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
         StreamingConfig config = new StreamingConfig(props);
 
         KStreamBuilder builder = new KStreamBuilder();

--- a/SimpleCounter/src/main/java/com/shapira/examples/producer/simplecounter/DemoProducerNewJava.java
+++ b/SimpleCounter/src/main/java/com/shapira/examples/producer/simplecounter/DemoProducerNewJava.java
@@ -36,16 +36,16 @@ public class DemoProducerNewJava implements DemoProducer {
     @Override
     public void configure(String brokerList, String sync) {
         this.sync = sync;
-        kafkaProps.put("bootstrap.servers", brokerList);
+        kafkaProps.setProperty("bootstrap.servers", brokerList);
 
         // This is mandatory, even though we don't send keys
-        kafkaProps.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        kafkaProps.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        kafkaProps.put("acks", "1");
+        kafkaProps.setProperty("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        kafkaProps.setProperty("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        kafkaProps.setProperty("acks", "1");
 
         // how many times to retry when produce request fails?
-        kafkaProps.put("retries", "3");
-        kafkaProps.put("linger.ms", 5);
+        kafkaProps.setProperty("retries", "3");
+        kafkaProps.setProperty("linger.ms", "5");
     }
 
     @Override

--- a/SimpleCounter/src/main/java/com/shapira/examples/producer/simplecounter/DemoProducerOld.java
+++ b/SimpleCounter/src/main/java/com/shapira/examples/producer/simplecounter/DemoProducerOld.java
@@ -37,12 +37,12 @@ public class DemoProducerOld implements DemoProducer{
 
     @Override
     public void configure(String brokerList, String sync) {
-        kafkaProps.put("metadata.broker.list", brokerList);
-        kafkaProps.put("serializer.class", "kafka.serializer.StringEncoder");
-        kafkaProps.put("request.required.acks", "1");
-        kafkaProps.put("producer.type", sync);
-        kafkaProps.put("send.buffer.bytes","550000");
-        kafkaProps.put("receive.buffer.bytes","550000");
+        kafkaProps.setProperty("metadata.broker.list", brokerList);
+        kafkaProps.setProperty("serializer.class", "kafka.serializer.StringEncoder");
+        kafkaProps.setProperty("request.required.acks", "1");
+        kafkaProps.setProperty("producer.type", sync);
+        kafkaProps.setProperty("send.buffer.bytes","550000");
+        kafkaProps.setProperty("receive.buffer.bytes","550000");
 
         config = new ProducerConfig(kafkaProps);
     }

--- a/SimpleMovingAvg/src/main/java/com/shapira/examples/newconsumer/simplemovingavg/SimpleMovingAvgNewConsumer.java
+++ b/SimpleMovingAvg/src/main/java/com/shapira/examples/newconsumer/simplemovingavg/SimpleMovingAvgNewConsumer.java
@@ -86,11 +86,11 @@ public class SimpleMovingAvgNewConsumer {
     }
 
     private void configure(String servers, String groupId) {
-        kafkaProps.put("group.id",groupId);
-        kafkaProps.put("bootstrap.servers",servers);
-        kafkaProps.put("auto.offset.reset","earliest");         // when in doubt, read everything
-        kafkaProps.put("key.deserializer","org.apache.kafka.common.serialization.StringDeserializer");
-        kafkaProps.put("value.deserializer","org.apache.kafka.common.serialization.StringDeserializer");
+        kafkaProps.setProperty("group.id",groupId);
+        kafkaProps.setProperty("bootstrap.servers",servers);
+        kafkaProps.setProperty("auto.offset.reset","earliest");         // when in doubt, read everything
+        kafkaProps.setProperty("key.deserializer","org.apache.kafka.common.serialization.StringDeserializer");
+        kafkaProps.setProperty("value.deserializer","org.apache.kafka.common.serialization.StringDeserializer");
         consumer = new KafkaConsumer<String, String>(kafkaProps);
     }
 

--- a/SimpleMovingAvg/src/main/java/com/shapira/examples/zkconsumer/simplemovingavg/SimpleMovingAvgZkConsumer.java
+++ b/SimpleMovingAvg/src/main/java/com/shapira/examples/zkconsumer/simplemovingavg/SimpleMovingAvgZkConsumer.java
@@ -92,16 +92,16 @@ public class SimpleMovingAvgZkConsumer {
     }
 
     private void configure(String zkUrl, String groupId) {
-        kafkaProps.put("zookeeper.connect", zkUrl);
-        kafkaProps.put("group.id",groupId);
-        kafkaProps.put("auto.commit.interval.ms","1000");
-        kafkaProps.put("auto.offset.reset","largest");
+        kafkaProps.setProperty("zookeeper.connect", zkUrl);
+        kafkaProps.setProperty("group.id",groupId);
+        kafkaProps.setProperty("auto.commit.interval.ms","1000");
+        kafkaProps.setProperty("auto.offset.reset","largest");
 
         // un-comment this if you want to commit offsets manually
-        //kafkaProps.put("auto.commit.enable","false");
+        //kafkaProps.setProperty("auto.commit.enable","false");
 
         // un-comment this if you don't want to wait for data indefinitely
-        kafkaProps.put("consumer.timeout.ms",waitTime);
+        kafkaProps.setProperty("consumer.timeout.ms",waitTime);
 
         config = new ConsumerConfig(kafkaProps);
     }


### PR DESCRIPTION
Invoking `HashTable`'s put method on a `Properties` object is strongly
discouraged. Use `Properties`' `setProperty` method instead.

Source: https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html
