### PR TITLE
add maven compiler plugin version 1.6

### DIFF
--- a/SimpleMovingAvg/pom.xml
+++ b/SimpleMovingAvg/pom.xml
@@ -41,6 +41,14 @@
                     <finalName>uber-${artifactId}-${version}</finalName>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
add maven compiler plugin version 1.6, otherwise maven will use java 1.3 to compile the source code, which will lead for-each loop and generic errors.
