### PR TITLE
Upgrade Kafka bits metadata handle no longer needed

### DIFF
--- a/MirrorMakerHandler/pom.xml
+++ b/MirrorMakerHandler/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.11</artifactId>
-            <version>0.9.0.0</version>
+            <version>0.10.0.1</version>
         </dependency>
     </dependencies>
 

--- a/MirrorMakerHandler/src/main/java/com/shapira/examples/TopicSwitchingHandler.java
+++ b/MirrorMakerHandler/src/main/java/com/shapira/examples/TopicSwitchingHandler.java
@@ -1,13 +1,11 @@
 package com.shapira.examples;
 
-
-import kafka.consumer.BaseConsumerRecord;
-import kafka.message.MessageAndMetadata;
 import kafka.tools.MirrorMaker;
+import kafka.consumer.BaseConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Collections;
 
 public class TopicSwitchingHandler implements MirrorMaker.MirrorMakerMessageHandler {
 
@@ -15,10 +13,6 @@ public class TopicSwitchingHandler implements MirrorMaker.MirrorMakerMessageHand
 
     public TopicSwitchingHandler(String topicPrefix) {
         this.topicPrefix = topicPrefix;
-    }
-
-    public List<ProducerRecord<byte[], byte[]>> handle(MessageAndMetadata<byte[], byte[]> record) {
-        return Collections.singletonList(new ProducerRecord<byte[], byte[]>(topicPrefix + "." + record.topic(), record.partition(), record.key(), record.message()));
     }
 
     public List<ProducerRecord<byte[], byte[]>> handle(BaseConsumerRecord record) {


### PR DESCRIPTION
ref for metadata based handle removal:

10.0.1
https://github.com/confluentinc/kafka/blob/v3.0.1/core/src/main/scala/kafka/tools/MirrorMaker.scala#L673-L675

0.9.0.0
https://github.com/confluentinc/kafka/blob/0.9.0.0/core/src/main/scala/kafka/tools/MirrorMaker.scala#L634
